### PR TITLE
bugfix: skip invalid strings when creating setlist from batch

### DIFF
--- a/app/controllers/setlist_controller.rb
+++ b/app/controllers/setlist_controller.rb
@@ -42,6 +42,7 @@ class SetlistController < ApplicationController
     success = 0
     @batch.each_line do |line|
       splitted_line = line.split(' - ')
+      next unless splitted_line.length > 1
       artist = splitted_line[0].strip
       title = splitted_line[1].strip
       spotify_url = nil

--- a/app/controllers/setlist_controller.rb
+++ b/app/controllers/setlist_controller.rb
@@ -45,14 +45,9 @@ class SetlistController < ApplicationController
       next unless splitted_line.length > 1
       artist = splitted_line[0].strip
       title = splitted_line[1].strip
-      spotify_url = nil
-      if splitted_line.length > 2
-        spotify_url = splitted_line[2]
-      end
-      
+
       song = Song.where({"artist"=>artist, "title"=>title, "band_id"=>@band.id}).first_or_create
-      song.spotify_url = spotify_url
-      song.save
+
       if @setlist.add_song(song, nil)
         success += 1
       end
@@ -150,8 +145,7 @@ class SetlistController < ApplicationController
     # Trim the artist and title
     params[:song][:artist] = params[:song][:artist].strip
     params[:song][:title] = params[:song][:title].strip
-    params[:song][:spotify_url] = params[:song][:spotify_url].strip
-    params.require(:song).permit(:artist, :title, :spotify_url, :band_id)
+    params.require(:song).permit(:artist, :title, :band_id)
   end
   
 end

--- a/app/views/setlist/show.html.erb
+++ b/app/views/setlist/show.html.erb
@@ -115,7 +115,6 @@
           <div class="modal-body">
             <%= f.text_field :artist, id: 'artist', tabindex: "1" %>
             <%= f.text_field :title, id: 'title', tabindex: "2" %>
-            <%= f.text_field :spotify_url, id: 'spotify_url', tabindex: "3", label: 'Spotify URL (optional)'%>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-default" data-dismiss="modal" tabindex="5">Close</button>
@@ -159,8 +158,7 @@
             <p>Insert below the list of songs. Please follow the following rules:</p>
             <ul>
               <li>One song per line</li>
-              <li>Format without media URL: <strong>Artist - Title</strong> (don't forget the spaces before and after the dash)</li>
-              <li>Format with media URL: <strong>Artist - Title - URL</strong> (don't forget the spaces before and after the dashes)</li>
+              <li>Format: <strong>Artist - Title</strong> (don't forget the spaces before and after the dash)</li>
             </ul>
             <%= f.text_area :batch, rows: "10", tabindex: "1" %>
           </div>


### PR DESCRIPTION
When trying to update/create a setlist by adding a batch of songs, if one of the lines is not in the required format, the app breaks. This simple fix only skips lines like that.
Also, removing media url option to make it simpler for the user since it can be fetched automatically.
